### PR TITLE
checkout specific commit only

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
           node-version: 10.*


### PR DESCRIPTION
#10 を修正するpull requestです。[Danger fails on CI when running on PR from a fork in GH Actions / Buddy Build · Issue #1103 · danger/danger](https://github.com/danger/danger/issues/1103#issuecomment-635539947)にならって、コミットのみをみるようにしてみました。