### PR TITLE
package.json中のライセンスの修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/cto-a/policy-proposal/issues"
   },


### PR DESCRIPTION
#24 によると、ソフトウェアと文書すべてに対してMITを適用する方針のようなので、ISCの記載は誤りと思われます。